### PR TITLE
feat: minimal AI gateway v0

### DIFF
--- a/.github/workflows/gateway-dev.yml
+++ b/.github/workflows/gateway-dev.yml
@@ -1,0 +1,19 @@
+name: Gateway Worker Dev Deploy
+
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+    defaults:
+      run:
+        working-directory: apps/gateway-worker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Wrangler
+        run: npm install -g wrangler
+      - name: Deploy Worker
+        run: wrangler deploy

--- a/apps/gateway-worker/package.json
+++ b/apps/gateway-worker/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "gateway-worker",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240419.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/gateway-worker/src/index.ts
+++ b/apps/gateway-worker/src/index.ts
@@ -1,0 +1,64 @@
+export interface Env {
+  AI_PROVIDER_PRIMARY: string;
+  AI_ACCOUNT_ID_PRIMARY: string;
+  AI_API_KEY_PRIMARY: string;
+  ALLOWED_ORIGINS: string;
+  GATEWAY_PUBLIC_KEY: string;
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+    ...init,
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'OPTIONS') {
+      return handleOptions(request, env);
+    }
+
+    if (url.pathname !== '/v1/chat' || request.method !== 'POST') {
+      return new Response('Not found', { status: 404 });
+    }
+
+    const origin = request.headers.get('Origin') || '';
+    const allowedOrigins = env.ALLOWED_ORIGINS.split(',').map(o => o.trim());
+    if (!allowedOrigins.includes(origin)) {
+      return jsonResponse({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const apiKey = request.headers.get('X-API-Key');
+    if (apiKey !== env.GATEWAY_PUBLIC_KEY) {
+      return jsonResponse({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const requestId = crypto.randomUUID();
+    return jsonResponse(
+      { reply: 'Hello from gateway', requestId },
+      { headers: { 'Access-Control-Allow-Origin': origin } }
+    );
+  },
+};
+
+function handleOptions(request: Request, env: Env): Response {
+  const origin = request.headers.get('Origin') || '';
+  const allowedOrigins = env.ALLOWED_ORIGINS.split(',').map(o => o.trim());
+  if (!allowedOrigins.includes(origin)) {
+    return new Response(null, { status: 403 });
+  }
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': origin,
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, X-API-Key',
+    },
+  });
+}

--- a/apps/gateway-worker/tsconfig.json
+++ b/apps/gateway-worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["ES2023"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/gateway-worker/wrangler.toml
+++ b/apps/gateway-worker/wrangler.toml
@@ -1,0 +1,3 @@
+name = "gateway-worker"
+main = "src/index.ts"
+compatibility_date = "2024-05-08"


### PR DESCRIPTION
## Summary
- scaffold a minimal Cloudflare Worker gateway with a placeholder `/v1/chat` endpoint
- add wrangler config and GitHub Action to deploy on `dev` branch

## Testing
- `npm install --no-package-lock`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d0372be4832592396b3c8736d529