### PR TITLE
Add CORS headers to gateway error responses

### DIFF
--- a/apps/gateway-worker/src/index.ts
+++ b/apps/gateway-worker/src/index.ts
@@ -31,12 +31,18 @@ export default {
     const origin = request.headers.get('Origin') || '';
     const allowedOrigins = env.ALLOWED_ORIGINS.split(',').map(o => o.trim());
     if (!allowedOrigins.includes(origin)) {
-      return jsonResponse({ error: 'Forbidden' }, { status: 403 });
+      return jsonResponse(
+        { error: 'Forbidden' },
+        { status: 403, headers: { 'Access-Control-Allow-Origin': origin } }
+      );
     }
 
     const apiKey = request.headers.get('X-API-Key');
     if (apiKey !== env.GATEWAY_PUBLIC_KEY) {
-      return jsonResponse({ error: 'Unauthorized' }, { status: 401 });
+      return jsonResponse(
+        { error: 'Unauthorized' },
+        { status: 401, headers: { 'Access-Control-Allow-Origin': origin } }
+      );
     }
 
     const requestId = crypto.randomUUID();
@@ -51,7 +57,10 @@ function handleOptions(request: Request, env: Env): Response {
   const origin = request.headers.get('Origin') || '';
   const allowedOrigins = env.ALLOWED_ORIGINS.split(',').map(o => o.trim());
   if (!allowedOrigins.includes(origin)) {
-    return new Response(null, { status: 403 });
+    return new Response(null, {
+      status: 403,
+      headers: { 'Access-Control-Allow-Origin': origin },
+    });
   }
   return new Response(null, {
     status: 204,


### PR DESCRIPTION
## Summary
- include `Access-Control-Allow-Origin` on 403 and 401 JSON responses
- add same CORS header to OPTIONS 403 handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d39779788325aee371e3c1cabef1