### PR TITLE
chore(ci): standardize dev deploy workflow

### DIFF
--- a/.github/workflows/gateway-dev.yml
+++ b/.github/workflows/gateway-dev.yml
@@ -1,19 +1,31 @@
-name: Gateway Worker Dev Deploy
-
+name: "gateway: deploy (dev)"
 on:
   push:
-    branches: [dev]
-
+    branches: ["dev"]
+concurrency:
+  group: gateway-dev-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: dev
-    defaults:
-      run:
-        working-directory: apps/gateway-worker
     steps:
       - uses: actions/checkout@v4
-      - name: Install Wrangler
-        run: npm install -g wrangler
-      - name: Deploy Worker
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - run: npm i -g wrangler
+      - name: Deploy with Wrangler
+        working-directory: apps/gateway-worker
         run: wrangler deploy
+        env:
+          AI_PROVIDER_PRIMARY: ${{ vars.AI_PROVIDER_PRIMARY }}
+          AI_ACCOUNT_ID_PRIMARY: ${{ vars.AI_ACCOUNT_ID_PRIMARY }}
+          ALLOWED_ORIGINS: ${{ vars.ALLOWED_ORIGINS }}
+          AI_API_KEY_PRIMARY: ${{ secrets.AI_API_KEY_PRIMARY }}
+          GATEWAY_PUBLIC_KEY: ${{ secrets.GATEWAY_PUBLIC_KEY }}
+      - name: Summary
+        run: |
+          echo "## Deployed gateway (dev)" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: $GITHUB_REF_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "- Worker path: apps/gateway-worker" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- standardize dev gateway deploy workflow with concurrency and wrangler deployment

## Testing
- `npm test` *(fails: expected 200 to be 500)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898dbfa42748325aeb29fbca57b0c5b