### PR TITLE
feat(embeddings): add /v1/embeddings with provider router

### DIFF
--- a/apps/gateway-worker/src/index.test.ts
+++ b/apps/gateway-worker/src/index.test.ts
@@ -1,5 +1,5 @@
 import worker from './index';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 const env = {
   AI_PROVIDER_PRIMARY: 'noop',
@@ -61,6 +61,67 @@ describe('gateway worker', () => {
       },
     });
     const res = await worker.fetch(req, env);
+    expect(res.status).toBe(401);
+    const data = await res.json<any>();
+    expect(data).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('handles embeddings requests', async () => {
+    const embEnv = {
+      ...env,
+      AI_PROVIDER_PRIMARY: 'cloudflare-workers-ai',
+      AI_ACCOUNT_ID_PRIMARY: 'acc',
+      AI_API_KEY_PRIMARY: 'key',
+    };
+    const mockRes = { result: { data: [[0.1, 0.2]] } };
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify(mockRes), { status: 200 })
+    );
+    const origFetch = global.fetch;
+    (global as any).fetch = fetchMock as any;
+
+    const req = new Request('https://example.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://example.com',
+        'X-API-Key': 'valid-key',
+      },
+      body: JSON.stringify({ input: 'hi' }),
+    });
+    const res = await worker.fetch(req, embEnv);
+    (global as any).fetch = origFetch;
+    expect(res.status).toBe(200);
+    const data = await res.json<any>();
+    expect(Array.isArray(data.data[0].embedding)).toBe(true);
+  });
+
+  it('rejects embeddings requests with missing input', async () => {
+    const embEnv = { ...env, AI_PROVIDER_PRIMARY: 'cloudflare-workers-ai' };
+    const req = new Request('https://example.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://example.com',
+        'X-API-Key': 'valid-key',
+      },
+      body: JSON.stringify({}),
+    });
+    const res = await worker.fetch(req, embEnv);
+    expect(res.status).toBe(400);
+    const data = await res.json<any>();
+    expect(data).toEqual({ error: 'Bad request' });
+  });
+
+  it('rejects embeddings requests with bad API key', async () => {
+    const embEnv = { ...env, AI_PROVIDER_PRIMARY: 'cloudflare-workers-ai' };
+    const req = new Request('https://example.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://example.com',
+        'X-API-Key': 'invalid-key',
+      },
+      body: JSON.stringify({ input: 'hi' }),
+    });
+    const res = await worker.fetch(req, embEnv);
     expect(res.status).toBe(401);
     const data = await res.json<any>();
     expect(data).toEqual({ error: 'Unauthorized' });

--- a/apps/gateway-worker/src/providers/cloudflare.ts
+++ b/apps/gateway-worker/src/providers/cloudflare.ts
@@ -1,0 +1,26 @@
+import type { Env } from '../index';
+import type { EmbeddingsArgs, EmbeddingsResult } from './index';
+
+export async function runEmbeddingsCF(
+  { input }: EmbeddingsArgs,
+  env: Env
+): Promise<EmbeddingsResult> {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${env.AI_ACCOUNT_ID_PRIMARY}/ai/run/@cf/baai/bge-m3`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.AI_API_KEY_PRIMARY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ input }),
+  });
+  if (!res.ok) {
+    throw new Error('Upstream request failed');
+  }
+  const json = (await res.json()) as any;
+  const embeddings: number[][] = json?.result?.data || [];
+  return {
+    data: embeddings.map((embedding: number[], index: number) => ({ embedding, index })),
+    model: '@cf/baai/bge-m3',
+  };
+}

--- a/apps/gateway-worker/src/providers/index.ts
+++ b/apps/gateway-worker/src/providers/index.ts
@@ -1,0 +1,26 @@
+import type { Env } from '../index';
+import { runEmbeddingsCF } from './cloudflare';
+
+export interface EmbeddingsArgs {
+  input: string | string[];
+}
+
+export interface EmbeddingItem {
+  embedding: number[];
+  index: number;
+}
+
+export interface EmbeddingsResult {
+  data: EmbeddingItem[];
+  model: string;
+}
+
+export async function runEmbeddings(
+  { input }: EmbeddingsArgs,
+  env: Env
+): Promise<EmbeddingsResult> {
+  if (env.AI_PROVIDER_PRIMARY === 'cloudflare-workers-ai') {
+    return runEmbeddingsCF({ input }, env);
+  }
+  throw new Error('Not implemented');
+}


### PR DESCRIPTION
## Summary
- add `/v1/embeddings` endpoint and provider routing
- implement Cloudflare embeddings provider
- cover embeddings success and error cases with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ddf16b1083258254bf8c27077c33