### PR TITLE
feat(config+ops): env-driven model slugs and /health,/version

### DIFF
--- a/.github/workflows/gateway-dev.yml
+++ b/.github/workflows/gateway-dev.yml
@@ -24,6 +24,7 @@ jobs:
           ALLOWED_ORIGINS: ${{ vars.ALLOWED_ORIGINS }}
           AI_API_KEY_PRIMARY: ${{ secrets.AI_API_KEY_PRIMARY }}
           GATEWAY_PUBLIC_KEY: ${{ secrets.GATEWAY_PUBLIC_KEY }}
+          GIT_SHA: ${{ github.sha }}
       - name: Summary
         run: |
           echo "## Deployed gateway (dev)" >> $GITHUB_STEP_SUMMARY

--- a/apps/gateway-worker/README.md
+++ b/apps/gateway-worker/README.md
@@ -1,0 +1,17 @@
+# Gateway Worker
+
+## Environment Variables
+- `AI_PROVIDER_PRIMARY`
+- `AI_ACCOUNT_ID_PRIMARY`
+- `AI_API_KEY_PRIMARY`
+- `ALLOWED_ORIGINS`
+- `GATEWAY_PUBLIC_KEY`
+- `AI_MODEL_CHAT_PRIMARY`
+- `AI_MODEL_EMBEDDINGS_PRIMARY`
+- `GIT_SHA` (CI-injected for `/version`)
+
+## Endpoints
+- `POST /v1/chat`
+- `POST /v1/embeddings`
+- `GET /health` – returns `{ "ok": true }`
+- `GET /version` – returns `{ "gitSha": "<short-sha>", "timestamp": "<ISO>" }`

--- a/apps/gateway-worker/src/index.test.ts
+++ b/apps/gateway-worker/src/index.test.ts
@@ -5,6 +5,8 @@ const env = {
   AI_PROVIDER_PRIMARY: 'noop',
   AI_ACCOUNT_ID_PRIMARY: 'noop',
   AI_API_KEY_PRIMARY: 'noop',
+  AI_MODEL_CHAT_PRIMARY: '@cf/test/chat',
+  AI_MODEL_EMBEDDINGS_PRIMARY: '@cf/test/embed',
   ALLOWED_ORIGINS: 'https://example.com',
   GATEWAY_PUBLIC_KEY: 'valid-key',
 };
@@ -22,6 +24,7 @@ describe('gateway worker', () => {
     expect(res.status).toBe(200);
     const data = await res.json<any>();
     expect(data.reply).toBe('Hello from gateway');
+    expect(data.model).toBe(env.AI_MODEL_CHAT_PRIMARY);
     expect(typeof data.requestId).toBe('string');
   });
 
@@ -72,13 +75,14 @@ describe('gateway worker', () => {
       AI_PROVIDER_PRIMARY: 'cloudflare-workers-ai',
       AI_ACCOUNT_ID_PRIMARY: 'acc',
       AI_API_KEY_PRIMARY: 'key',
+      AI_MODEL_EMBEDDINGS_PRIMARY: '@cf/baai/bge-m3',
     };
     const mockRes = { result: { data: [[0.1, 0.2]] } };
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response(JSON.stringify(mockRes), { status: 200 })
     );
-    const origFetch = global.fetch;
-    (global as any).fetch = fetchMock as any;
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = fetchMock as any;
 
     const req = new Request('https://example.com/v1/embeddings', {
       method: 'POST',
@@ -89,14 +93,19 @@ describe('gateway worker', () => {
       body: JSON.stringify({ input: 'hi' }),
     });
     const res = await worker.fetch(req, embEnv);
-    (global as any).fetch = origFetch;
+    (globalThis as any).fetch = origFetch;
     expect(res.status).toBe(200);
     const data = await res.json<any>();
     expect(Array.isArray(data.data[0].embedding)).toBe(true);
+    expect(data.model).toBe(embEnv.AI_MODEL_EMBEDDINGS_PRIMARY);
   });
 
   it('rejects embeddings requests with missing input', async () => {
-    const embEnv = { ...env, AI_PROVIDER_PRIMARY: 'cloudflare-workers-ai' };
+    const embEnv = {
+      ...env,
+      AI_PROVIDER_PRIMARY: 'cloudflare-workers-ai',
+      AI_MODEL_EMBEDDINGS_PRIMARY: '@cf/baai/bge-m3',
+    };
     const req = new Request('https://example.com/v1/embeddings', {
       method: 'POST',
       headers: {
@@ -112,7 +121,11 @@ describe('gateway worker', () => {
   });
 
   it('rejects embeddings requests with bad API key', async () => {
-    const embEnv = { ...env, AI_PROVIDER_PRIMARY: 'cloudflare-workers-ai' };
+    const embEnv = {
+      ...env,
+      AI_PROVIDER_PRIMARY: 'cloudflare-workers-ai',
+      AI_MODEL_EMBEDDINGS_PRIMARY: '@cf/baai/bge-m3',
+    };
     const req = new Request('https://example.com/v1/embeddings', {
       method: 'POST',
       headers: {
@@ -125,5 +138,49 @@ describe('gateway worker', () => {
     expect(res.status).toBe(401);
     const data = await res.json<any>();
     expect(data).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns health status', async () => {
+    const req = new Request('https://example.com/health', {
+      method: 'GET',
+      headers: {
+        Origin: 'https://example.com',
+        'X-API-Key': 'valid-key',
+      },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(200);
+    const data = await res.json<any>();
+    expect(data).toEqual({ ok: true });
+  });
+
+  it('returns version info with git sha', async () => {
+    const versionEnv = { ...env, GIT_SHA: '1234567890abcdef' };
+    const req = new Request('https://example.com/version', {
+      method: 'GET',
+      headers: {
+        Origin: 'https://example.com',
+        'X-API-Key': 'valid-key',
+      },
+    });
+    const res = await worker.fetch(req, versionEnv);
+    expect(res.status).toBe(200);
+    const data = await res.json<any>();
+    expect(data.gitSha).toBe('1234567');
+    expect(typeof data.timestamp).toBe('string');
+  });
+
+  it('returns version info with unknown git sha when not provided', async () => {
+    const req = new Request('https://example.com/version', {
+      method: 'GET',
+      headers: {
+        Origin: 'https://example.com',
+        'X-API-Key': 'valid-key',
+      },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(200);
+    const data = await res.json<any>();
+    expect(data.gitSha).toBe('unknown');
   });
 });

--- a/apps/gateway-worker/src/providers/cloudflare.ts
+++ b/apps/gateway-worker/src/providers/cloudflare.ts
@@ -5,7 +5,8 @@ export async function runEmbeddingsCF(
   { input }: EmbeddingsArgs,
   env: Env
 ): Promise<EmbeddingsResult> {
-  const url = `https://api.cloudflare.com/client/v4/accounts/${env.AI_ACCOUNT_ID_PRIMARY}/ai/run/@cf/baai/bge-m3`;
+  const model = env.AI_MODEL_EMBEDDINGS_PRIMARY;
+  const url = `https://api.cloudflare.com/client/v4/accounts/${env.AI_ACCOUNT_ID_PRIMARY}/ai/run/${model}`;
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -21,6 +22,6 @@ export async function runEmbeddingsCF(
   const embeddings: number[][] = json?.result?.data || [];
   return {
     data: embeddings.map((embedding: number[], index: number) => ({ embedding, index })),
-    model: '@cf/baai/bge-m3',
+    model,
   };
 }

--- a/apps/gateway-worker/src/providers/index.ts
+++ b/apps/gateway-worker/src/providers/index.ts
@@ -12,7 +12,7 @@ export interface EmbeddingItem {
 
 export interface EmbeddingsResult {
   data: EmbeddingItem[];
-  model: string;
+  model: string | undefined;
 }
 
 export async function runEmbeddings(


### PR DESCRIPTION
## Summary
- drive chat and embeddings model selection via env vars and surface chosen model in responses
- add lightweight /health and /version endpoints requiring standard auth
- capture git SHA in CI for version reporting

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898dfe0c17c83258a8d05936fb484b1