### PR TITLE
feat: add runtime configuration asset

### DIFF
--- a/apps/web/angular.json
+++ b/apps/web/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {
@@ -48,12 +49,13 @@
             "polyfills": [],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              {
-                "glob": "**/*",
-                "input": "src/assets"
-              }
-            ],
+              "assets": [
+                "src/assets/runtime-config.json",
+                {
+                  "glob": "**/*",
+                  "input": "src/assets"
+                }
+              ],
             "styles": [
               "src/styles.scss"
             ],

--- a/apps/web/src/assets/runtime-config.json
+++ b/apps/web/src/assets/runtime-config.json
@@ -1,0 +1,3 @@
+{
+  "gatewayUrl": "http://localhost:8787"
+}


### PR DESCRIPTION
## Summary
- add runtime-config.json to ship gateway URL at runtime
- include runtime-config.json in Angular build assets

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689904a96c6c8325a019557bb333d628