### PR TITLE
fix: handle runtime config fetch failures

### DIFF
--- a/apps/web/src/app/core/config-loader.service.ts
+++ b/apps/web/src/app/core/config-loader.service.ts
@@ -4,12 +4,28 @@ export interface RuntimeConfig {
   gatewayUrl: string;
 }
 
+const DEFAULT_CONFIG: RuntimeConfig = {
+  gatewayUrl: '',
+};
+
 @Injectable({ providedIn: 'root' })
 export class ConfigLoaderService {
   config = signal<RuntimeConfig | null>(null);
 
   async load(): Promise<void> {
-    const res = await fetch('assets/runtime-config.json');
-    this.config.set(await res.json());
+    try {
+      const res = await fetch('assets/runtime-config.json');
+      if (!res.ok) {
+        console.error(
+          `Failed to load runtime config: ${res.status} ${res.statusText}`,
+        );
+        this.config.set(DEFAULT_CONFIG);
+        return;
+      }
+      this.config.set(await res.json());
+    } catch (err) {
+      console.error('Error loading runtime config', err);
+      this.config.set(DEFAULT_CONFIG);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- avoid boot failure when runtime-config.json is missing
- default to a blank gateway URL if config fetch fails

## Testing
- `cd apps/web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689904b6899c83258feddefed64bc1b6