### PR TITLE
chore(web): document and set base href for subpath deploy

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -18,3 +18,13 @@ Angular 18 app using standalone APIs, Angular Material and zoneless change detec
    ```
 
 The CI pipeline injects `runtime-config.json` from `${{ vars.GATEWAY_URL }}`. The client never stores secrets.
+
+## Deployment
+
+When hosting the app from a subpath such as `/a4ya-edu/`, build with the corresponding `base-href` so that all assets and API calls resolve correctly:
+
+```bash
+npm run build -- --base-href /a4ya-edu/
+```
+
+This command injects `<base href="/a4ya-edu/">` into the generated `index.html`.

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Web</title>
-  <base href="/">
+  <base href="/a4ya-edu/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext x='50%25' y='55%25' font-size='80' text-anchor='middle'%3EA%3C/text%3E%3C/svg%3E">
 </head>


### PR DESCRIPTION
## Summary
- update base tag to use `/a4ya-edu/`
- document building with `--base-href /a4ya-edu/`

## Testing
- `npm test`
- `npm run build -- --base-href /a4ya-edu/`


------
https://chatgpt.com/codex/tasks/task_e_68993040fb448325af413f873c016d3b