### PR TITLE
Use base URI for runtime config and keep default on failure

### DIFF
--- a/apps/web/src/app/core/config-loader.service.ts
+++ b/apps/web/src/app/core/config-loader.service.ts
@@ -10,22 +10,21 @@ const DEFAULT_CONFIG: RuntimeConfig = {
 
 @Injectable({ providedIn: 'root' })
 export class ConfigLoaderService {
-  config = signal<RuntimeConfig | null>(null);
+  config = signal<RuntimeConfig>(DEFAULT_CONFIG);
 
   async load(): Promise<void> {
+    const url = new URL('assets/runtime-config.json', document.baseURI).href;
     try {
-      const res = await fetch('assets/runtime-config.json');
+      const res = await fetch(url);
       if (!res.ok) {
         console.error(
           `Failed to load runtime config: ${res.status} ${res.statusText}`,
         );
-        this.config.set(DEFAULT_CONFIG);
         return;
       }
       this.config.set(await res.json());
     } catch (err) {
       console.error('Error loading runtime config', err);
-      this.config.set(DEFAULT_CONFIG);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Resolve runtime configuration using `document.baseURI` so production builds load `/assets/runtime-config.json` correctly
- Preserve and log default configuration when fetching runtime config fails

## Testing
- `npm test`
- `npm run build`
- Manual Node script to confirm config URL resolution and gateway API base

------
https://chatgpt.com/codex/tasks/task_e_6899303556b08325862b0da499ffc95e