### PR TITLE
Refactor layout with standalone topbar and sidebar components

### DIFF
--- a/apps/web/src/app/layout/main-shell.component.html
+++ b/apps/web/src/app/layout/main-shell.component.html
@@ -1,30 +1,27 @@
-<mat-sidenav-container class="h-screen">
-  <mat-sidenav #snav [mode]="isHandset() ? 'over' : 'side'" [opened]="!isHandset()" class="w-64">
-    <mat-nav-list>
-      <div mat-subheader>Experimental</div>
-      <a mat-list-item routerLink="experimental/api-debug" routerLinkActive="active">API Debug</a>
-      <mat-divider></mat-divider>
-      <a mat-list-item routerLink="about" routerLinkActive="active">About us</a>
-    </mat-nav-list>
-  </mat-sidenav>
+<div class="flex h-screen flex-col">
+  <app-topbar class="sticky top-0 z-10"></app-topbar>
+  <mat-sidenav-container class="flex-1">
+    <mat-sidenav
+      #snav
+      [mode]="isHandset() ? 'over' : 'side'"
+      [opened]="!isHandset()"
+      class="w-64"
+    >
+      <app-sidebar></app-sidebar>
+    </mat-sidenav>
 
-  <mat-sidenav-content class="h-full flex flex-col">
-    <mat-toolbar color="primary" class="sticky top-0 z-10">
-      <button mat-icon-button (click)="snav.toggle()">
-        <mat-icon>menu</mat-icon>
+    <mat-sidenav-content class="relative h-full flex flex-col">
+      <button
+        mat-mini-fab
+        color="primary"
+        class="absolute top-4 -left-3 z-20"
+        (click)="snav.toggle()"
+      >
+        <mat-icon>{{ snav.opened ? 'chevron_left' : 'chevron_right' }}</mat-icon>
       </button>
-      <span class="ml-2 font-semibold">a4ya-edu</span>
-      <span class="flex-1"></span>
-      <button mat-icon-button [matMenuTriggerFor]="menu">
-        <mat-icon>menu</mat-icon>
-      </button>
-    </mat-toolbar>
-    <mat-menu #menu="matMenu">
-      <button mat-menu-item routerLink="about">About us</button>
-      <button mat-menu-item (click)="logout()">Logout</button>
-    </mat-menu>
-    <div class="flex-1 overflow-auto p-4 md:p-6">
-      <router-outlet></router-outlet>
-    </div>
-  </mat-sidenav-content>
-</mat-sidenav-container>
+      <div class="flex-1 overflow-auto p-4 md:p-6">
+        <router-outlet></router-outlet>
+      </div>
+    </mat-sidenav-content>
+  </mat-sidenav-container>
+</div>

--- a/apps/web/src/app/layout/main-shell.component.ts
+++ b/apps/web/src/app/layout/main-shell.component.ts
@@ -1,37 +1,28 @@
 import { Component, inject, signal } from '@angular/core';
-import { RouterLink, RouterLinkActive, RouterOutlet, Router } from '@angular/router';
-import { MatToolbarModule } from '@angular/material/toolbar';
+import { RouterOutlet } from '@angular/router';
+import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatListModule } from '@angular/material/list';
-import { MatDividerModule } from '@angular/material/divider';
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { AuthService } from '../core/auth.service';
+import { TopbarComponent } from './topbar.component';
+import { SidebarComponent } from './sidebar.component';
 
 @Component({
   selector: 'app-main-shell',
   standalone: true,
   imports: [
     RouterOutlet,
-    RouterLink,
-    RouterLinkActive,
-    MatToolbarModule,
+    MatSidenavModule,
     MatButtonModule,
     MatIconModule,
-    MatMenuModule,
-    MatSidenavModule,
-    MatListModule,
-    MatDividerModule,
+    TopbarComponent,
+    SidebarComponent,
   ],
   templateUrl: './main-shell.component.html',
   styleUrls: ['./main-shell.component.scss'],
 })
 export class MainShellComponent {
   private breakpointObserver = inject(BreakpointObserver);
-  private router = inject(Router);
-  auth = inject(AuthService);
 
   isHandset = signal(false);
 
@@ -39,10 +30,5 @@ export class MainShellComponent {
     this.breakpointObserver.observe('(max-width: 959px)').subscribe((result) => {
       this.isHandset.set(result.matches);
     });
-  }
-
-  logout() {
-    this.auth.signOut();
-    this.router.navigate(['/login']);
   }
 }

--- a/apps/web/src/app/layout/sidebar.component.html
+++ b/apps/web/src/app/layout/sidebar.component.html
@@ -1,0 +1,6 @@
+<mat-nav-list>
+  <div mat-subheader>Experimental</div>
+  <a mat-list-item routerLink="experimental/api-debug" routerLinkActive="active">API Debug</a>
+  <mat-divider></mat-divider>
+  <a mat-list-item routerLink="about" routerLinkActive="active">About us</a>
+</mat-nav-list>

--- a/apps/web/src/app/layout/sidebar.component.scss
+++ b/apps/web/src/app/layout/sidebar.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/apps/web/src/app/layout/sidebar.component.ts
+++ b/apps/web/src/app/layout/sidebar.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { MatListModule } from '@angular/material/list';
+import { MatDividerModule } from '@angular/material/divider';
+
+@Component({
+  selector: 'app-sidebar',
+  standalone: true,
+  imports: [RouterLink, RouterLinkActive, MatListModule, MatDividerModule],
+  templateUrl: './sidebar.component.html',
+  styleUrls: ['./sidebar.component.scss'],
+})
+export class SidebarComponent {}

--- a/apps/web/src/app/layout/topbar.component.html
+++ b/apps/web/src/app/layout/topbar.component.html
@@ -1,0 +1,11 @@
+<mat-toolbar color="primary" class="w-full">
+  <span class="ml-2 font-semibold">a4ya-edu</span>
+  <span class="flex-1"></span>
+  <button mat-icon-button [matMenuTriggerFor]="menu">
+    <mat-icon>menu</mat-icon>
+  </button>
+</mat-toolbar>
+<mat-menu #menu="matMenu">
+  <button mat-menu-item routerLink="about">About us</button>
+  <button mat-menu-item (click)="logout()">Logout</button>
+</mat-menu>

--- a/apps/web/src/app/layout/topbar.component.scss
+++ b/apps/web/src/app/layout/topbar.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/apps/web/src/app/layout/topbar.component.ts
+++ b/apps/web/src/app/layout/topbar.component.ts
@@ -1,0 +1,25 @@
+import { Component, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { AuthService } from '../core/auth.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-topbar',
+  standalone: true,
+  imports: [RouterLink, MatToolbarModule, MatButtonModule, MatIconModule, MatMenuModule],
+  templateUrl: './topbar.component.html',
+  styleUrls: ['./topbar.component.scss'],
+})
+export class TopbarComponent {
+  private router = inject(Router);
+  auth = inject(AuthService);
+
+  logout() {
+    this.auth.signOut();
+    this.router.navigate(['/login']);
+  }
+}


### PR DESCRIPTION
## Summary
- Extract top bar into standalone `TopbarComponent` with user menu
- Extract navigation into standalone `SidebarComponent`
- Restructure `MainShellComponent` to place top bar above sidenav and add arrow toggle on sidebar edge

## Testing
- `cd apps/web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a7321d0948325bcf24b8595456c8b