### PR TITLE
Refactor layout into dedicated top bar and sidebar components

### DIFF
--- a/apps/web/src/app/layout/main-shell.component.html
+++ b/apps/web/src/app/layout/main-shell.component.html
@@ -1,30 +1,9 @@
-<mat-sidenav-container class="h-screen">
-  <mat-sidenav #snav [mode]="isHandset() ? 'over' : 'side'" [opened]="!isHandset()" class="w-64">
-    <mat-nav-list>
-      <div mat-subheader>Experimental</div>
-      <a mat-list-item routerLink="experimental/api-debug" routerLinkActive="active">API Debug</a>
-      <mat-divider></mat-divider>
-      <a mat-list-item routerLink="about" routerLinkActive="active">About us</a>
-    </mat-nav-list>
-  </mat-sidenav>
-
-  <mat-sidenav-content class="h-full flex flex-col">
-    <mat-toolbar color="primary" class="sticky top-0 z-10">
-      <button mat-icon-button (click)="snav.toggle()">
-        <mat-icon>menu</mat-icon>
-      </button>
-      <span class="ml-2 font-semibold">a4ya-edu</span>
-      <span class="flex-1"></span>
-      <button mat-icon-button [matMenuTriggerFor]="menu">
-        <mat-icon>menu</mat-icon>
-      </button>
-    </mat-toolbar>
-    <mat-menu #menu="matMenu">
-      <button mat-menu-item routerLink="about">About us</button>
-      <button mat-menu-item (click)="logout()">Logout</button>
-    </mat-menu>
+<div class="flex flex-col h-screen">
+  <app-top-bar></app-top-bar>
+  <div class="flex flex-1 overflow-hidden">
+    <app-sidebar [collapsed]="collapsed()" (collapsedChange)="collapsed.set($event)"></app-sidebar>
     <div class="flex-1 overflow-auto p-4 md:p-6">
       <router-outlet></router-outlet>
     </div>
-  </mat-sidenav-content>
-</mat-sidenav-container>
+  </div>
+</div>

--- a/apps/web/src/app/layout/main-shell.component.ts
+++ b/apps/web/src/app/layout/main-shell.component.ts
@@ -1,48 +1,26 @@
 import { Component, inject, signal } from '@angular/core';
-import { RouterLink, RouterLinkActive, RouterOutlet, Router } from '@angular/router';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatListModule } from '@angular/material/list';
-import { MatDividerModule } from '@angular/material/divider';
+import { RouterOutlet } from '@angular/router';
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { AuthService } from '../core/auth.service';
+import { TopBarComponent } from './top-bar/top-bar.component';
+import { SidebarComponent } from './sidebar/sidebar.component';
 
 @Component({
   selector: 'app-main-shell',
   standalone: true,
-  imports: [
-    RouterOutlet,
-    RouterLink,
-    RouterLinkActive,
-    MatToolbarModule,
-    MatButtonModule,
-    MatIconModule,
-    MatMenuModule,
-    MatSidenavModule,
-    MatListModule,
-    MatDividerModule,
-  ],
+  imports: [RouterOutlet, TopBarComponent, SidebarComponent],
   templateUrl: './main-shell.component.html',
   styleUrls: ['./main-shell.component.scss'],
 })
 export class MainShellComponent {
   private breakpointObserver = inject(BreakpointObserver);
-  private router = inject(Router);
-  auth = inject(AuthService);
 
-  isHandset = signal(false);
+  collapsed = signal(true);
 
   constructor() {
     this.breakpointObserver.observe('(max-width: 959px)').subscribe((result) => {
-      this.isHandset.set(result.matches);
+      if (!result.matches) {
+        this.collapsed.set(false);
+      }
     });
-  }
-
-  logout() {
-    this.auth.signOut();
-    this.router.navigate(['/login']);
   }
 }

--- a/apps/web/src/app/layout/sidebar/sidebar.component.html
+++ b/apps/web/src/app/layout/sidebar/sidebar.component.html
@@ -1,0 +1,20 @@
+<aside
+  class="h-full bg-gray-100 border-r relative transition-all duration-300 overflow-visible"
+  [class.w-64]="!collapsed"
+  [class.w-0]="collapsed"
+>
+  <button
+    mat-mini-fab
+    color="primary"
+    class="absolute top-1/2 -right-3 transform -translate-y-1/2"
+    (click)="toggle()"
+  >
+    <mat-icon>{{ collapsed ? 'chevron_right' : 'chevron_left' }}</mat-icon>
+  </button>
+  <mat-nav-list *ngIf="!collapsed">
+    <div mat-subheader>Experimental</div>
+    <a mat-list-item routerLink="experimental/api-debug" routerLinkActive="active">API Debug</a>
+    <mat-divider></mat-divider>
+    <a mat-list-item routerLink="about" routerLinkActive="active">About us</a>
+  </mat-nav-list>
+</aside>

--- a/apps/web/src/app/layout/sidebar/sidebar.component.scss
+++ b/apps/web/src/app/layout/sidebar/sidebar.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/apps/web/src/app/layout/sidebar/sidebar.component.ts
+++ b/apps/web/src/app/layout/sidebar/sidebar.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { NgIf } from '@angular/common';
+import { MatListModule } from '@angular/material/list';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-sidebar',
+  standalone: true,
+  imports: [NgIf, RouterLink, RouterLinkActive, MatListModule, MatIconModule, MatDividerModule, MatButtonModule],
+  templateUrl: './sidebar.component.html',
+  styleUrls: ['./sidebar.component.scss'],
+})
+export class SidebarComponent {
+  @Input() collapsed = false;
+  @Output() collapsedChange = new EventEmitter<boolean>();
+
+  toggle() {
+    this.collapsed = !this.collapsed;
+    this.collapsedChange.emit(this.collapsed);
+  }
+}

--- a/apps/web/src/app/layout/top-bar/top-bar.component.html
+++ b/apps/web/src/app/layout/top-bar/top-bar.component.html
@@ -1,0 +1,11 @@
+<mat-toolbar color="primary" class="w-full z-10">
+  <span class="ml-2 font-semibold">a4ya-edu</span>
+  <span class="flex-1"></span>
+  <button mat-icon-button [matMenuTriggerFor]="menu">
+    <mat-icon>account_circle</mat-icon>
+  </button>
+</mat-toolbar>
+<mat-menu #menu="matMenu">
+  <button mat-menu-item routerLink="about">About us</button>
+  <button mat-menu-item (click)="logout()">Logout</button>
+</mat-menu>

--- a/apps/web/src/app/layout/top-bar/top-bar.component.scss
+++ b/apps/web/src/app/layout/top-bar/top-bar.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/apps/web/src/app/layout/top-bar/top-bar.component.ts
+++ b/apps/web/src/app/layout/top-bar/top-bar.component.ts
@@ -1,0 +1,24 @@
+import { Component, inject } from '@angular/core';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { Router, RouterLink } from '@angular/router';
+import { AuthService } from '../../core/auth.service';
+
+@Component({
+  selector: 'app-top-bar',
+  standalone: true,
+  imports: [MatToolbarModule, MatButtonModule, MatIconModule, MatMenuModule, RouterLink],
+  templateUrl: './top-bar.component.html',
+  styleUrls: ['./top-bar.component.scss'],
+})
+export class TopBarComponent {
+  private auth = inject(AuthService);
+  private router = inject(Router);
+
+  logout() {
+    this.auth.signOut();
+    this.router.navigate(['/login']);
+  }
+}


### PR DESCRIPTION
## Summary
- Extract standalone top bar and sidebar components
- Add collapsible sidebar arrow toggle and full-width top bar
- Adjust main shell to compose new layout

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a7321d0948325bcf24b8595456c8b