### PR TITLE
feat(web): add experimental image resizer

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -29,9 +29,16 @@ After a mock login the app redirects to `/app/experimental/api-debug`. The `/app
 Navigation links include:
 
 - **Experimental → API Debug** (`/app/experimental/api-debug`)
+- **Experimental → Image Resizer** (`/app/experimental/image-resizer`)
 - **About us** (`/app/about`)
 
 The header also exposes a menu with "About us" and "Logout" actions.
+
+## Image Resizer
+
+The experimental Image Resizer at `/app/experimental/image-resizer` lets you batch resize JPEG, PNG or WebP files. Upload images via drag-and-drop or file picker, choose a preset size (256, 512, 1024, 1920 or 3840) or provide custom dimensions/percentage. Modes include **Fit**, **Cover**, **Stretch** and **Contain with background**. Output format can stay original or convert to **JPEG**, **PNG** or **WebP**; quality (0.1–1.0) affects JPEG/WebP only. Processed files use the pattern `<name>_<width>x<height>.<ext>` and can be downloaded individually or as a ZIP.
+
+Processing occurs inside a Web Worker using `createImageBitmap` and `OffscreenCanvas` for performance. EXIF metadata is stripped by default. Files over 50 MB or larger than ~10 000 px are rejected; animated formats are not supported.
 
 ## Theming
 

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -22,6 +22,7 @@
         "@ngrx/signals": "^18.1.1",
         "@ngrx/store": "^18.1.1",
         "@ngrx/store-devtools": "^18.1.1",
+        "jszip": "^3.10.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
       },
@@ -5746,8 +5747,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -7474,6 +7474,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
@@ -7528,8 +7534,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "4.1.3",
@@ -7772,8 +7777,7 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
@@ -8022,6 +8026,48 @@
       "engines": [
         "node >= 0.2.0"
       ]
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/karma": {
       "version": "6.4.4",
@@ -8388,6 +8434,15 @@
         "webpack-sources": {
           "optional": true
         }
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -9883,6 +9938,12 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10391,8 +10452,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -11225,6 +11285,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -12512,8 +12578,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@ngrx/signals": "^18.1.1",
     "@ngrx/store": "^18.1.1",
     "@ngrx/store-devtools": "^18.1.1",
+    "jszip": "^3.10.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },
@@ -33,15 +34,15 @@
     "@angular/cli": "^18.2.20",
     "@angular/compiler-cli": "^18.2.0",
     "@types/jasmine": "~5.1.0",
+    "autoprefixer": "^10.4.16",
     "jasmine-core": "~5.2.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.5.2",
-    "tailwindcss": "^3.4.4",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "tailwindcss": "^3.4.4",
+    "typescript": "~5.5.2"
   }
 }

--- a/apps/web/src/app/features/experimental/experimental.routes.ts
+++ b/apps/web/src/app/features/experimental/experimental.routes.ts
@@ -3,6 +3,11 @@ import { ApiDebugComponent } from '../api-debug/api-debug.component';
 
 export const EXPERIMENTAL_ROUTES: Routes = [
   { path: 'api-debug', component: ApiDebugComponent },
+  {
+    path: 'image-resizer',
+    loadComponent: () =>
+      import('../image-resizer/image-resizer.component').then(m => m.ImageResizerComponent),
+  },
   { path: '', pathMatch: 'full', redirectTo: 'api-debug' },
   { path: '**', redirectTo: 'api-debug' },
 ];

--- a/apps/web/src/app/features/image-resizer/download.service.ts
+++ b/apps/web/src/app/features/image-resizer/download.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class DownloadService {
+  downloadBlob(fileName: string, blob: Blob) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+}

--- a/apps/web/src/app/features/image-resizer/image-processing.worker.ts
+++ b/apps/web/src/app/features/image-resizer/image-processing.worker.ts
@@ -1,0 +1,136 @@
+/// <reference lib="webworker" />
+
+interface ProcessRequest {
+  id: number;
+  op: 'process';
+  fileName: string;
+  arrayBuffer: ArrayBuffer;
+  settings: ResizeSettings;
+}
+
+interface ResizeSettings {
+  preset?: number | null;
+  customWidth?: number | null;
+  customHeight?: number | null;
+  percentage?: number | null;
+  aspectLock: boolean;
+  mode: 'fit' | 'cover' | 'stretch' | 'contain';
+  background: string;
+  format: 'original' | 'image/jpeg' | 'image/png' | 'image/webp';
+  quality: number;
+  stripMetadata: boolean;
+  originalType: string;
+}
+
+interface ProcessResult {
+  fileName: string;
+  arrayBuffer: ArrayBuffer;
+  mimeType: string;
+  width: number;
+  height: number;
+  bytes: number;
+}
+
+addEventListener('message', async ({ data }) => {
+  const msg = data as ProcessRequest;
+  if (msg.op !== 'process') return;
+  try {
+    const blob = new Blob([msg.arrayBuffer]);
+    let bitmap = await createImageBitmap(blob, { imageOrientation: 'from-image' });
+    const originalWidth = bitmap.width;
+    const originalHeight = bitmap.height;
+
+    const { targetWidth, targetHeight } = computeTargetDimensions(originalWidth, originalHeight, msg.settings);
+    const { canvas, width, height } = drawBitmap(bitmap, targetWidth, targetHeight, msg.settings);
+
+    const mimeType = msg.settings.format === 'original' ? msg.settings.originalType : msg.settings.format;
+    const outBlob = await canvas.convertToBlob({ type: mimeType, quality: msg.settings.quality });
+    const ab = await outBlob.arrayBuffer();
+    const result: ProcessResult = {
+      fileName: msg.fileName,
+      arrayBuffer: ab,
+      mimeType,
+      width,
+      height,
+      bytes: outBlob.size,
+    };
+    (postMessage as any)({ id: msg.id, status: 'done', result }, [ab]);
+  } catch (err: any) {
+    (postMessage as any)({ id: msg.id, status: 'error', error: err?.message ?? 'Unknown error' });
+  }
+});
+
+function computeTargetDimensions(w: number, h: number, s: ResizeSettings) {
+  let tw = w;
+  let th = h;
+  if (s.preset) {
+    tw = s.preset;
+    th = Math.round((h / w) * tw);
+  }
+  if (s.percentage) {
+    tw = Math.round(w * s.percentage / 100);
+    th = Math.round(h * s.percentage / 100);
+  }
+  if (s.customWidth) {
+    tw = s.customWidth;
+    th = s.aspectLock ? Math.round((h / w) * tw) : (s.customHeight ?? th);
+  }
+  if (s.customHeight) {
+    th = s.customHeight;
+    tw = s.aspectLock ? Math.round((w / h) * th) : (s.customWidth ?? tw);
+  }
+  if (s.customWidth && s.customHeight && !s.aspectLock) {
+    tw = s.customWidth;
+    th = s.customHeight;
+  }
+  return { targetWidth: tw, targetHeight: th };
+}
+
+function drawBitmap(bitmap: ImageBitmap, tw: number, th: number, s: ResizeSettings) {
+  let canvas: OffscreenCanvas;
+  let ctx: OffscreenCanvasRenderingContext2D;
+  let width = tw;
+  let height = th;
+  const ow = bitmap.width;
+  const oh = bitmap.height;
+
+  if (s.mode === 'fit') {
+    const scale = Math.min(tw / ow, th / oh);
+    width = Math.round(ow * scale);
+    height = Math.round(oh * scale);
+    canvas = new OffscreenCanvas(width, height);
+    ctx = canvas.getContext('2d')!;
+    ctx.drawImage(bitmap, 0, 0, width, height);
+  } else if (s.mode === 'cover') {
+    canvas = new OffscreenCanvas(tw, th);
+    ctx = canvas.getContext('2d')!;
+    const scale = Math.max(tw / ow, th / oh);
+    const dw = ow * scale;
+    const dh = oh * scale;
+    const dx = (tw - dw) / 2;
+    const dy = (th - dh) / 2;
+    ctx.drawImage(bitmap, dx, dy, dw, dh);
+    width = tw;
+    height = th;
+  } else if (s.mode === 'stretch') {
+    canvas = new OffscreenCanvas(tw, th);
+    ctx = canvas.getContext('2d')!;
+    ctx.drawImage(bitmap, 0, 0, tw, th);
+    width = tw;
+    height = th;
+  } else { // contain with background
+    canvas = new OffscreenCanvas(tw, th);
+    ctx = canvas.getContext('2d')!;
+    ctx.fillStyle = s.background || '#ffffff';
+    ctx.fillRect(0, 0, tw, th);
+    const scale = Math.min(tw / ow, th / oh);
+    const dw = ow * scale;
+    const dh = oh * scale;
+    const dx = (tw - dw) / 2;
+    const dy = (th - dh) / 2;
+    ctx.drawImage(bitmap, dx, dy, dw, dh);
+    width = tw;
+    height = th;
+  }
+  return { canvas, width, height };
+}

--- a/apps/web/src/app/features/image-resizer/image-resizer.component.html
+++ b/apps/web/src/app/features/image-resizer/image-resizer.component.html
@@ -1,0 +1,120 @@
+<mat-toolbar color="primary">Image Resizer</mat-toolbar>
+<div class="p-4 grid gap-4 md:grid-cols-2">
+  <!-- Left panel -->
+  <div class="flex flex-col gap-4">
+    <mat-card>
+      <mat-card-title>Input & Settings</mat-card-title>
+      <mat-card-content>
+        <!-- Upload zone -->
+        <div class="border-2 border-dashed p-4 text-center" (drop)="onDrop($event)" (dragover)="onDragOver($event)">
+          <p>Drag & drop images here or</p>
+          <button mat-stroked-button color="primary" (click)="fileInput.click()">Select files</button>
+          <input #fileInput type="file" multiple accept="image/jpeg,image/png,image/webp" (change)="onFilesSelected($event)" hidden>
+        </div>
+
+        <!-- Files table -->
+        <table *ngIf="files().length" class="w-full mt-4 text-sm">
+          <thead>
+            <tr>
+              <th class="w-8"><mat-checkbox [(ngModel)]="allSelected" (change)="toggleAll(allSelected)"></mat-checkbox></th>
+              <th class="text-left">File</th>
+              <th class="text-left">Dimensions</th>
+              <th class="text-left">Size</th>
+              <th class="text-left">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let f of files(); trackBy: trackById">
+              <td><mat-checkbox [(ngModel)]="f.selected"></mat-checkbox></td>
+              <td>{{f.name}}</td>
+              <td>{{f.originalWidth}}×{{f.originalHeight}}</td>
+              <td>{{f.size}}</td>
+              <td>{{f.status}}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <!-- Settings -->
+        <div class="mt-4 grid gap-4">
+          <div class="flex flex-wrap gap-2">
+            <button mat-stroked-button *ngFor="let p of presets" (click)="applyPreset(p)">{{p}}</button>
+          </div>
+          <div class="grid grid-cols-2 gap-2">
+            <mat-form-field appearance="outline">
+             <mat-label>Width</mat-label>
+              <input matInput type="number" [ngModel]="customWidth()" (ngModelChange)="customWidth.set($event)">
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>Height</mat-label>
+              <input matInput type="number" [ngModel]="customHeight()" (ngModelChange)="customHeight.set($event)">
+            </mat-form-field>
+          </div>
+          <mat-checkbox [ngModel]="aspectLock()" (ngModelChange)="aspectLock.set($event)">Aspect ratio lock</mat-checkbox>
+          <mat-form-field appearance="outline">
+            <mat-label>Percentage</mat-label>
+            <input matInput type="number" [ngModel]="percentage()" (ngModelChange)="percentage.set($event)">
+            <span matSuffix>%</span>
+          </mat-form-field>
+          <mat-form-field appearance="outline">
+            <mat-label>Mode</mat-label>
+            <mat-select [ngModel]="mode()" (ngModelChange)="mode.set($event)">
+              <mat-option value="fit">Fit</mat-option>
+              <mat-option value="cover">Cover</mat-option>
+              <mat-option value="stretch">Stretch</mat-option>
+              <mat-option value="contain">Contain with background</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field appearance="outline" *ngIf="mode() === 'contain'">
+            <mat-label>Background</mat-label>
+            <input matInput type="color" [ngModel]="background()" (ngModelChange)="background.set($event)">
+          </mat-form-field>
+          <mat-form-field appearance="outline">
+            <mat-label>Output format</mat-label>
+            <mat-select [ngModel]="format()" (ngModelChange)="format.set($event)">
+              <mat-option value="original">Original</mat-option>
+              <mat-option value="image/jpeg">JPEG</mat-option>
+              <mat-option value="image/png">PNG</mat-option>
+              <mat-option value="image/webp">WebP</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <div class="flex items-center gap-2" *ngIf="format() === 'image/jpeg' || format() === 'image/webp'">
+            <span>Quality</span>
+            <mat-slider min="0.1" max="1" step="0.1" [ngModel]="quality()" (ngModelChange)="quality.set($event)" class="flex-1"></mat-slider>
+            <span>{{quality() | number:'1.1-1'}}</span>
+          </div>
+          <div>Filename: {{filenamePreview()}}</div>
+          <mat-checkbox [ngModel]="stripMetadata()" (ngModelChange)="stripMetadata.set($event)">Strip metadata</mat-checkbox>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </div>
+
+  <!-- Right panel -->
+  <div class="flex flex-col gap-4">
+    <mat-card class="flex-1">
+      <mat-card-title>Preview & Actions</mat-card-title>
+      <mat-card-content>
+        <div *ngIf="previewFile() as pf" class="text-center">
+          <img [src]="previewMode() === 'before' ? pf.previewUrl : pf.result?.url || pf.previewUrl" [alt]="pf.name" class="max-w-full mx-auto" />
+          <div class="mt-2 text-sm">
+            {{previewMode() === 'before' ? 'Original' : 'Processed'}}:
+            {{pf.result?.width || pf.originalWidth}}×{{pf.result?.height || pf.originalHeight}} -
+            {{pf.result?.bytes || pf.size}} bytes
+          </div>
+        </div>
+      </mat-card-content>
+      <mat-card-actions class="flex justify-center">
+        <button mat-button (click)="togglePreview()">Toggle Before/After</button>
+      </mat-card-actions>
+    </mat-card>
+    <mat-card>
+      <mat-card-actions class="flex flex-wrap gap-2">
+        <button mat-raised-button color="primary" (click)="processSelected()" [disabled]="processing()">Process Selected</button>
+        <button mat-raised-button (click)="downloadSelected()" [disabled]="!hasProcessedSelected()">Download Selected</button>
+        <button mat-raised-button (click)="downloadAll()" [disabled]="!hasAnyProcessed()">Download All (ZIP)</button>
+        <button mat-button (click)="reset()">Reset</button>
+      </mat-card-actions>
+      <mat-progress-bar *ngIf="processing()" mode="indeterminate"></mat-progress-bar>
+    </mat-card>
+  </div>
+</div>

--- a/apps/web/src/app/features/image-resizer/image-resizer.component.scss
+++ b/apps/web/src/app/features/image-resizer/image-resizer.component.scss
@@ -1,0 +1,11 @@
+:host {
+  display: block;
+}
+
+th, td {
+  @apply px-2 py-1;
+}
+
+table {
+  @apply border-collapse;
+}

--- a/apps/web/src/app/features/image-resizer/image-resizer.component.ts
+++ b/apps/web/src/app/features/image-resizer/image-resizer.component.ts
@@ -1,0 +1,267 @@
+import { Component, OnDestroy, signal, computed, effect } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { DownloadService } from './download.service';
+import { ZipService } from './zip.service';
+
+interface FileItem {
+  id: number;
+  file: File;
+  name: string;
+  size: number;
+  originalWidth?: number;
+  originalHeight?: number;
+  previewUrl?: string;
+  selected: boolean;
+  status: 'queued' | 'processing' | 'done' | 'error';
+  result?: {
+    blob: Blob;
+    url: string;
+    mimeType: string;
+    width: number;
+    height: number;
+    bytes: number;
+    fileName: string;
+  };
+}
+
+@Component({
+  selector: 'app-image-resizer',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatToolbarModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatSliderModule,
+    MatCheckboxModule,
+    MatProgressBarModule,
+    MatSnackBarModule,
+  ],
+  templateUrl: './image-resizer.component.html',
+  styleUrls: ['./image-resizer.component.scss'],
+})
+export class ImageResizerComponent implements OnDestroy {
+  private worker = new Worker(new URL('./image-processing.worker', import.meta.url), {
+    type: 'module',
+  });
+  private nextId = 0;
+
+  readonly files = signal<FileItem[]>([]);
+  readonly presets = [256, 512, 1024, 1920, 3840];
+
+  readonly preset = signal<number | null>(null);
+  readonly customWidth = signal<number | null>(null);
+  readonly customHeight = signal<number | null>(null);
+  readonly percentage = signal<number | null>(null);
+  readonly aspectLock = signal(true);
+  readonly mode = signal<'fit' | 'cover' | 'stretch' | 'contain'>('fit');
+  readonly background = signal('#ffffff');
+  readonly format = signal<'original' | 'image/jpeg' | 'image/png' | 'image/webp'>('original');
+  readonly quality = signal(0.8);
+  readonly stripMetadata = signal(true);
+  readonly previewMode = signal<'before' | 'after'>('after');
+  readonly processing = signal(false);
+  allSelected = false;
+
+  readonly selectedFiles = computed(() => this.files().filter(f => f.selected));
+  readonly previewFile = computed(() => this.selectedFiles()[0] ?? this.files()[0]);
+  readonly filenamePreview = computed(() => {
+    const f = this.previewFile();
+    if (!f) return '';
+    const base = f.name.replace(/\.[^.]+$/, '');
+    const width = f.result?.width || f.originalWidth || 0;
+    const height = f.result?.height || f.originalHeight || 0;
+    const ext = this.format() === 'original' ? (f.file.type.split('/')[1] || 'png') : this.format().split('/')[1];
+    return `${base}_${width}x${height}.${ext}`;
+  });
+  readonly hasAnyProcessed = computed(() => this.files().some(f => f.status === 'done'));
+  readonly hasProcessedSelected = computed(() => this.selectedFiles().some(f => f.status === 'done'));
+
+  constructor(private snack: MatSnackBar, private downloader: DownloadService, private zipper: ZipService) {
+    this.worker.onmessage = this.onWorkerMessage.bind(this);
+    effect(() => {
+      const all = this.files().length > 0 && this.files().every(f => f.selected);
+      this.allSelected = all;
+    });
+  }
+
+  private onWorkerMessage(ev: MessageEvent<any>) {
+    const { id, status, result, error } = ev.data;
+    const files = this.files();
+    const idx = files.findIndex(f => f.id === id);
+    if (idx === -1) return;
+    const item = files[idx];
+    if (status === 'done') {
+      const blob = new Blob([result.arrayBuffer], { type: result.mimeType });
+      const url = URL.createObjectURL(blob);
+      item.result = {
+        blob,
+        url,
+        mimeType: result.mimeType,
+        width: result.width,
+        height: result.height,
+        bytes: result.bytes,
+        fileName: this.buildFileName(item, result.mimeType, result.width, result.height),
+      };
+      item.status = 'done';
+    } else {
+      item.status = 'error';
+      this.snack.open(error || 'Processing failed', undefined, { duration: 3000 });
+    }
+    this.files.set([...files]);
+    if (!this.files().some(f => f.status === 'processing')) {
+      this.processing.set(false);
+    }
+  }
+
+  private buildFileName(item: FileItem, mime: string, w: number, h: number) {
+    const base = item.name.replace(/\.[^.]+$/, '');
+    const ext = this.format() === 'original' ? (mime.split('/')[1] || 'png') : this.format().split('/')[1];
+    return `${base}_${w}x${h}.${ext}`;
+  }
+
+  async addFiles(list: FileList) {
+    for (const file of Array.from(list)) {
+      if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+        this.snack.open('Unsupported file type', undefined, { duration: 2000 });
+        continue;
+      }
+      if (file.size > 50 * 1024 * 1024) {
+        this.snack.open('File too large', undefined, { duration: 2000 });
+        continue;
+      }
+      const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+      if (bitmap.width > 10000 || bitmap.height > 10000) {
+        this.snack.open('Image dimensions too large', undefined, { duration: 2000 });
+        continue;
+      }
+      const url = URL.createObjectURL(file);
+      const item: FileItem = {
+        id: ++this.nextId,
+        file,
+        name: file.name,
+        size: file.size,
+        originalWidth: bitmap.width,
+        originalHeight: bitmap.height,
+        previewUrl: url,
+        selected: true,
+        status: 'queued',
+      };
+      this.files.set([...this.files(), item]);
+    }
+  }
+
+  onFilesSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (input.files) {
+      this.addFiles(input.files);
+      input.value = '';
+    }
+  }
+
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    if (event.dataTransfer?.files) {
+      this.addFiles(event.dataTransfer.files);
+    }
+  }
+
+  onDragOver(event: DragEvent) { event.preventDefault(); }
+
+  applyPreset(p: number) {
+    this.preset.set(p);
+    this.customWidth.set(null);
+    this.customHeight.set(null);
+    this.percentage.set(null);
+  }
+
+  async processSelected() {
+    const items = this.selectedFiles();
+    if (!items.length) return;
+    this.processing.set(true);
+    for (const item of items) {
+      if (item.status === 'processing') continue;
+      item.status = 'processing';
+      const arrayBuffer = await item.file.arrayBuffer();
+      const settings = {
+        preset: this.preset(),
+        customWidth: this.customWidth(),
+        customHeight: this.customHeight(),
+        percentage: this.percentage(),
+        aspectLock: this.aspectLock(),
+        mode: this.mode(),
+        background: this.background(),
+        format: this.format(),
+        quality: this.quality(),
+        stripMetadata: this.stripMetadata(),
+        originalType: item.file.type,
+      };
+      this.worker.postMessage({ id: item.id, op: 'process', fileName: item.name, arrayBuffer, settings }, [arrayBuffer]);
+    }
+  }
+
+  downloadSelected() {
+    for (const item of this.selectedFiles()) {
+      if (item.result) {
+        this.downloader.downloadBlob(item.result.fileName, item.result.blob);
+      }
+    }
+  }
+
+  async downloadAll() {
+    for (const item of this.files()) {
+      if (item.result) {
+        this.zipper.addFile(item.result.fileName, item.result.blob);
+      }
+    }
+    const blob = await this.zipper.generate();
+    this.downloader.downloadBlob('images.zip', blob);
+    this.zipper.reset();
+  }
+
+  reset() {
+    this.files().forEach(f => {
+      if (f.previewUrl) URL.revokeObjectURL(f.previewUrl);
+      if (f.result?.url) URL.revokeObjectURL(f.result.url);
+    });
+    this.files.set([]);
+    this.zipper.reset();
+    this.preset.set(null);
+    this.customWidth.set(null);
+    this.customHeight.set(null);
+    this.percentage.set(null);
+    this.previewMode.set('after');
+  }
+
+  togglePreview() {
+    this.previewMode.set(this.previewMode() === 'before' ? 'after' : 'before');
+  }
+
+  toggleAll(val: boolean) {
+    this.files.set(this.files().map(f => ({ ...f, selected: val })));
+  }
+
+  trackById = (_: number, it: FileItem) => it.id;
+
+  ngOnDestroy() {
+    this.worker.terminate();
+    this.reset();
+  }
+}

--- a/apps/web/src/app/features/image-resizer/zip.service.ts
+++ b/apps/web/src/app/features/image-resizer/zip.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import JSZip from 'jszip';
+
+@Injectable({ providedIn: 'root' })
+export class ZipService {
+  private zip = new JSZip();
+
+  addFile(name: string, blob: Blob) {
+    this.zip.file(name, blob);
+  }
+
+  async generate(): Promise<Blob> {
+    return await this.zip.generateAsync({ type: 'blob' });
+  }
+
+  reset() {
+    this.zip = new JSZip();
+  }
+}

--- a/apps/web/src/app/layout/sidebar/sidebar.component.ts
+++ b/apps/web/src/app/layout/sidebar/sidebar.component.ts
@@ -42,6 +42,7 @@ export class SidebarComponent {
       route: 'experimental/api-debug',
       children: [
         { id: 'api', label: 'API Debug', icon: 'code', route: 'experimental/api-debug' },
+        { id: 'resize', label: 'Image Resizer', icon: 'image', route: 'experimental/image-resizer' },
       ],
     },
     { id: 'about', label: 'About us', icon: 'info', route: 'about', dividerAbove: true },


### PR DESCRIPTION
## Summary
- add standalone Image Resizer experimental tool with worker-based processing and zip download
- wire new Image Resizer route and sidebar link
- document Image Resizer usage and limits in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba1413bfc8325bc589eace07876b5